### PR TITLE
Fix string delay representation

### DIFF
--- a/src/StateChartNode.tsx
+++ b/src/StateChartNode.tsx
@@ -626,9 +626,9 @@ export class StateChartNode extends React.Component<
             if (typeof delay === 'string') {
               const delayExpr = stateNode.machine.options.delays[delay];
               delay =
-                typeof delayExpr === 'number'
-                  ? delayExpr
-                  : delayExpr(current.context, current.event);
+                typeof delayExpr === 'function'
+                  ? delayExpr(current.context, current.event)
+                  : Number(delay) || 0;
             }
 
             const isTransient = ownEvent === '';


### PR DESCRIPTION
Hi @amitnovick! 

This change fixes rendering of delayed transitions with dynamic delays, specified by a string
more here: https://xstate.js.org/docs/guides/delays.html#delayed-transitions

![image](https://user-images.githubusercontent.com/2446638/104810715-37d64b80-57ff-11eb-825c-2a18bc4a2044.png)
